### PR TITLE
add pair effect support

### DIFF
--- a/mothernet/tests/models/test_pair.py
+++ b/mothernet/tests/models/test_pair.py
@@ -1,0 +1,38 @@
+import numpy as np
+import pytest
+
+from mothernet.prediction.mothernet_additive import compute_top_pairs, MotherNetAdditiveClassifierPairEffects
+from mothernet.utils import get_mn_model
+
+np.random.seed(0)
+n = 200
+d = 10
+X = np.random.rand(n, d)
+# continuous xor with X0 and X3: x0 + x3 - 2 * x0 * x3
+# => requires pairwise effect and top pair should be (0, 3)
+y = X[:, 0] + X[:, 3] - 2 * X[:, 0] * X[:, 3]
+y = y > 0.5
+
+
+@pytest.mark.parametrize("n_pair_feature_max_ratio", [0, 0.5, 1.0])
+@pytest.mark.parametrize("pair_strategy", ["sum_importance", "fast"])
+def test_pair(n_pair_feature_max_ratio: float, pair_strategy: str):
+    pairs = compute_top_pairs(X, y, pair_strategy=pair_strategy, n_pair_feature_max_ratio=n_pair_feature_max_ratio)
+
+    assert len(pairs) == int(n_pair_feature_max_ratio * d)
+    if pairs:
+        assert pairs[0] == (0, 3)
+
+
+@pytest.mark.parametrize("n_pair_feature_max_ratio", [0, 0.1])
+@pytest.mark.parametrize("pair_strategy", ["sum_importance", "fast"])
+def test_estimator(n_pair_feature_max_ratio: float, pair_strategy: str):
+    baam_model_string = "baam_nsamples500_numfeatures10_04_07_2024_17_04_53_epoch_1780.cpkt"
+    clf = MotherNetAdditiveClassifierPairEffects(
+        path=get_mn_model(baam_model_string),
+        pair_strategy=pair_strategy,
+        n_pair_feature_max_ratio=n_pair_feature_max_ratio,
+    )
+    y_pred = clf.fit(X, y).predict(X)
+    if n_pair_feature_max_ratio > 0:
+        assert (y_pred == y).mean() > 0.9


### PR DESCRIPTION
Hi Andreas, here is a PR with the code to enable modelling pair effects as promised. 

I added support to use FAST to compute the pair order as I expect it would work much better than the naive approach I discussed yesterday.

Julien shared a code to evaluate on OpenML which I used, not sure if it is the same you used.

On the following task-ids: 9951, 272, 39, 31, 10093, 57, 37, 43, 9952, 14968, 9969, 9953 I got this average error:

```
                            cv_auc_mean  test_auc    fit_time
model                                                        
baam-best-pair-CV              0.809686  0.856514   65.049400
baam_0.0pairs                  0.798356  0.855195   56.724633
baam_0.1pairs                  0.801744  0.855656   65.050035
baam_0.2pairs                  0.799122  0.858965   71.765130
baam_0.4pairs                  0.798059  0.854595   79.616998
baam_0.8pairs                  0.794903  0.875098  106.113443
baam_0.9pairs                  0.792541  0.868467  111.863154
ebm_main_effects_optimized     0.772181  0.869489    1.447367
ebm_optimized                  0.774374  0.865137    8.557797
lr                             0.743742  0.835959    0.033622
```